### PR TITLE
feat: add network allowlists to agent templates

### DIFF
--- a/ai-radio/agent.yaml
+++ b/ai-radio/agent.yaml
@@ -4,9 +4,21 @@ description: "Transforms any text source into a polished, simulated radio show w
 tools:
   - type: google_search
   - type: code_execution
+  - type: url_context
 environment:
   type: "remote"
   sources: []
+  network:
+    allowlist:
+      - domain: "hacker-news.firebaseio.com"
+      - domain: "news.ycombinator.com"
+      - domain: "api.github.com"
+      - domain: "github.com"
+      - domain: "raw.githubusercontent.com"      
+      - domain: "pypi.org"
+      - domain: "files.pythonhosted.org"
+      - domain: "arxiv.org"
+      - domain: "en.wikipedia.org"
 examples:
   - title: "Daily Hacker Bites"
     prompt: "Generate a 3-minute radio show called Daily Hacker Bites based on top Hacker News stories."

--- a/data-analyst/agent.yaml
+++ b/data-analyst/agent.yaml
@@ -7,6 +7,11 @@ tools:
 environment:
   type: "remote"
   sources: []
+  network:
+    allowlist:
+      - domain: "github.com"
+      - domain: "pypi.org"
+      - domain: "files.pythonhosted.org"
 examples:
   - title: "Biggest Customer"
     prompt: "Who is my biggest customer?"

--- a/document-processor/agent.yaml
+++ b/document-processor/agent.yaml
@@ -10,6 +10,13 @@ environment:
     - type: "gcs"
       source: "gs://templates-data/document-processor"
       target: ".agents/workspace"
+  network:
+    allowlist:
+      - domain: "www.wikidata.org"    
+      - domain: "fonts.googleapis.com"
+      - domain: "fonts.gstatic.com"      
+      - domain: "pypi.org"
+      - domain: "files.pythonhosted.org"
 examples:
   - title: "Reconcile Expenses"
     prompt: "Reconcile expenses in expenses.csv with the invoices and flag all discrepancies."

--- a/repo-maintainer/agent.yaml
+++ b/repo-maintainer/agent.yaml
@@ -6,6 +6,10 @@ tools:
 environment:
   type: "remote"
   sources: []
+  network:
+    allowlist:     
+      - domain: "github.com"
+      - domain: "api.github.com"
 examples:
   - title: "Fix Critical Issue"
     prompt: "Clone https://github.com/googleapis/python-genai, find the most critical open issue and generate a .patch file to fix it."


### PR DESCRIPTION
Add policy-safe network allowlists to 4 agent templates:

- ai-radio: HN Firebase API, GitHub, PyPI, arxiv, Wikipedia + url_context tool
- data-analyst: GitHub (Northwind data), PyPI
- document-processor: Wikidata (CC0), Google Fonts, PyPI
- repo-maintainer: GitHub (clone + issues API)

customer-support intentionally left without allowlist since its core feature is scraping arbitrary user-provided URLs.

All allowlisted domains are either public APIs, Google-owned infrastructure, open-access/CC-licensed resources, or package registries. No copyrighted news sites or social media with restrictive ToS.