### PR TITLE
ci: secure matrix prompt variable in hourly-probe workflow

### DIFF
--- a/.github/workflows/hourly-probe.yml
+++ b/.github/workflows/hourly-probe.yml
@@ -79,11 +79,10 @@ jobs:
         id: run_probe
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          TEMPLATE: ${{ matrix.template }}
+          CHIP: ${{ matrix.chip }}
+          PROMPT: ${{ matrix.prompt }}
         run: |
-          TEMPLATE="${{ matrix.template }}"
-          CHIP="${{ matrix.chip }}"
-          PROMPT="${{ matrix.prompt }}"
-
           echo "Template: $TEMPLATE"
           echo "Chip: $CHIP"
           echo "Prompt: $PROMPT"


### PR DESCRIPTION
Move matrix variable interpolation from inline bash script compilation to process environment variable mapping to prevent command injection, syntax errors, and bash evaluation of double quotes/backticks in templates.