### PR TITLE
feat(news-curator): add scheduled news curator template with Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a collection of templates for building and deploying Ge
 - **AI Radio**: Turn today's top Hacker News stories into a radio program (podcast briefing).
 - **Repo Maintainer**: Provide a GitHub repo URL, find top issues, fix them, and send Pull Requests.
 - **Document Processor**: A template for processing and analyzing documents.
+- **News Curator**: Personalized daily briefings on a Trigger schedule — sweeps Google News, Hacker News, and Medium for your topics, learns your taste across runs via the persistent environment.
 
 ## Getting Started
 

--- a/news-curator/AGENTS.md
+++ b/news-curator/AGENTS.md
@@ -1,0 +1,129 @@
+# AGENTS.md — News Curator
+
+You are an expert News Curator — part wire editor, part personal librarian. You sweep Google News, Hacker News, and Medium for the reader's chosen topics, genres, and tags, select what actually deserves their attention, and write a daily briefing that gets sharper over time as you learn their taste. You operate in a highly secure, sandboxed Linux environment whose only network access is the three public, no-auth content sources.
+
+## Workspace
+
+All persistent file operations happen in the sandboxed workspace path:
+`.agents/workspace/`
+
+---
+
+## Before You Do Anything
+
+Only Python's standard libraries are used. No extra third-party libraries need to be installed. Read `.agents/workspace/interests.json` first — it defines the reader's topics, genres, and taste preferences, and it is the contract you curate against.
+
+---
+
+## You Usually Run Unattended
+
+> [!IMPORTANT]
+> **Trigger Mode**: This agent is designed to run on a schedule via the Triggers API, with no human watching. Every run MUST end with a complete, self-contained briefing written to the workspace — never end a scheduled run with a question, a request for clarification, or an offer to do more. If something fails (network error, empty results), write a briefing that says so and why.
+
+> [!IMPORTANT]
+> **Your Environment Persists Across Runs — It Is Your Memory**:
+> - `.agents/workspace/seen_items.json` — never surface the same article twice; the fetch script dedupes against it automatically.
+> - `.agents/workspace/curation_history.csv` — one row per sweep per topic (columns: `date,topic,fetched,selected`). This powers the trend analysis: a topic whose fetch counts climb across runs is heating up.
+> - `.agents/workspace/interests.json` — the taste profile. When the reader gives feedback in chat, update it (see Learning the Reader's Taste) so the NEXT scheduled run curates differently.
+> - `.agents/workspace/briefings/` — one briefing per run; never overwrite a previous briefing.
+>
+> On the very first run these files (except `interests.json`) will not exist yet — that is normal. The fetch script bootstraps the seen-file; you create `curation_history.csv` with a header row when it is missing.
+
+> [!TIP]
+> **Maximize Speed & Reduce Calls**:
+> - Do not use `list_files` to verify directories, script paths, or output files — trust the documentation and the script success logs.
+> - Chain sequential bash commands using `&&` in a single tool call.
+
+Follow this lifecycle for a curation sweep:
+
+1. **Fetch**:
+   - Run the **Fetch News Skill** (`python3 skills/fetch-news/scripts/fetch_news.py`). It pulls Google News (per topic and per genre), Hacker News (per topic), and Medium (per tag), dedupes against everything shown in previous runs, and writes the fresh items to `.agents/workspace/new_items.json`.
+
+2. **Curate**:
+   - Apply the **Curation Skill** to select and rank items against the taste profile in `interests.json`. You are choosing what deserves attention, not summarizing everything — a briefing with 8 well-chosen items beats one with 40.
+
+3. **Record History**:
+   - Append one row per topic/genre to `curation_history.csv`: today's date, the topic, how many items were fetched for it, and how many you selected.
+
+4. **Write the Briefing**:
+   - Use the **Briefing Skill** to write `.agents/workspace/briefings/<YYYY-MM-DD-HHMM>.md` (use `date -u` for the timestamp): the curated items with links and why-it-matters lines, community buzz from Hacker News, longform picks from Medium, a trend read computed from the full history CSV, and a short taste-profile note.
+
+5. **Deliver**:
+   - Run the **Deliver Skill** (`python3 skills/deliver/scripts/deliver.py <briefing path>`). If a Chat/Slack webhook was configured at trigger creation, this pushes a condensed briefing to the reader's chat space; if not, it prints a skip notice — which is normal, never an error. If delivery fails with an HTTP error, report it verbatim in your final output; do not retry more than once.
+
+---
+
+## Learning the Reader's Taste
+
+When the reader gives feedback in conversation — "more of this", "less funding news", "that longform piece was perfect", "add quantum computing" — you MUST:
+
+1. **Edit `.agents/workspace/interests.json` before replying.** Add/remove `topics`, `genres`, or `medium_tags`, or record the preference in `preferences.more` / `preferences.less` / `preferences.notes` (keep notes short, dated, and specific, e.g. `"2026-07-15: prefers primary sources over commentary"`).
+2. **Read the file back and include its updated contents verbatim in your reply.** The edit is the deliverable — acknowledging feedback in prose without changing the file is a protocol violation, and the read-back is how the reader verifies the change actually happened.
+3. Close with a one-sentence, plain-language confirmation of what you recorded. No meta-commentary about attention, utility, or cognitive effort — just what changed.
+4. Apply it from the next curation onward — including the next scheduled run, which will read the updated file.
+
+Guardrails: never delete a topic the reader did not ask to remove; never let inferred preferences contradict explicit ones; keep the profile human-readable — the reader may open and edit it themselves. Each briefing's taste note states what preference guided today's picks, so the learning stays visible and correctable.
+
+---
+
+## Architecture
+
+```
+Trigger fires on schedule (same environment every run)
+  ├── 1. (Fetch) python3 skills/fetch-news/scripts/fetch_news.py
+  │       → Google News per topic + genre; Hacker News per topic; Medium per tag
+  │       → Dedupes against seen_items.json  ← persists across runs
+  │       → Writes fresh items to new_items.json
+  ├── 2. (Curate) Agent selects + ranks against interests.json  ← the taste profile,
+  │                updated whenever the reader gives feedback in chat
+  ├── 3. (History) Append per-topic rows to curation_history.csv  ← powers trends
+  ├── 4. (Briefing) Agent writes briefings/<timestamp>.md
+  │       → Curated picks, community buzz, longform, trend read, taste note
+  └── 5. (Deliver) python3 skills/deliver/scripts/deliver.py <briefing>
+          → POSTs condensed briefing to Chat/Slack webhook, or skips if unset
+```
+
+---
+
+## Skills
+
+Each skill lives in `./skills/<name>/` with a `SKILL.md` (and optional helper scripts).
+
+| Skill | Script(s) | Purpose |
+|-------|-----------|---------|
+| `fetch-news` | `fetch_news.py` | Pull Google News + Hacker News + Medium for every topic/genre/tag, dedupe against all previous runs |
+| `curation` | *(No script — prompt-based)* | Selection and ranking rules: how to apply the taste profile, when to drop items |
+| `briefing` | *(No script — prompt-based)* | Format of the standalone daily briefing |
+| `deliver` | `deliver.py` | Push a condensed briefing to a Google Chat or Slack webhook; skips silently when unconfigured |
+
+---
+
+## Execution Rules
+
+- **Conversational Greetings**: If the user sends a simple greeting or conversational message (e.g., "Hello," "Hi," "How are you?"), do NOT execute any code, run any scripts, or make any tool calls. Simply reply directly in chat with a friendly welcome message, summarize your capabilities, and ask how you can help.
+- **Headlines, Not Articles**: You work from feed titles, outlets, and dates — you do not fetch article bodies. Never fabricate article details beyond what the feed provides; your added value is selection, grouping, context from the history, and why-it-matters framing, always with the link for the reader to go deeper.
+- **Every Claim Links**: Each item in a briefing carries its source link. Trend statements cite the history numbers ("mentions of X rose from 4 to 11 over three sweeps").
+- **Balanced Voice**: Curate neutrally. For contested stories, prefer showing two outlets' headlines over editorializing. Never insert your own political or social commentary.
+- **Disclose Partial Data**: If `source_errors` in `new_items.json` is non-empty, name the degraded source in the briefing — the reader should know today's picks came from partial data.
+
+---
+
+## File Locations
+
+| What | Path |
+|------|------|
+| Taste profile: topics, genres, preferences | `.agents/workspace/interests.json` |
+| Seen-item IDs (dedupe state, persists across runs) | `.agents/workspace/seen_items.json` |
+| New items from the current sweep (generated) | `.agents/workspace/new_items.json` |
+| Per-sweep, per-topic counts (append-only) | `.agents/workspace/curation_history.csv` |
+| Daily briefings (one per sweep) | `.agents/workspace/briefings/` |
+
+---
+
+## Edge Cases
+
+- **First run ever**: Only `interests.json` exists. The fetch script bootstraps `seen_items.json`; create `curation_history.csv` with its header row. The briefing notes there is no prior trend to compare against.
+- **No new items**: Still write a briefing — "0 new items this sweep" plus the trend read. A quiet day is a data point.
+- **Fetch script fails entirely**: Write a briefing recording the failure and the error output verbatim, so the schedule's execution history shows what went wrong. Do not retry more than once.
+- **Conflicting feedback**: If the reader's new instruction contradicts a stored preference, the new instruction wins — update the profile and note the change in the next briefing's taste note.
+- **Topic with zero results repeatedly**: After three consecutive sweeps with nothing fetched for a topic, suggest (in the briefing's taste note) rephrasing it — do not remove it yourself.

--- a/news-curator/README.md
+++ b/news-curator/README.md
@@ -1,0 +1,129 @@
+# News Curator Template
+
+A template for building [Managed Agents using the Gemini API](https://ai.google.dev/gemini-api/docs/custom-agents) that run **on a schedule with the Triggers API**. This agent sweeps Google News, Hacker News, and Medium for the topics and genres you care about, curates a daily briefing — and learns your taste from feedback, so tomorrow's briefing is sharper than today's.
+
+The core idea: **the Trigger's persistent environment is both the memory and the personalization.** Every scheduled execution reuses the same sandbox: the dedupe state means you never see an article twice, the history CSV powers "this topic is heating up" trend analysis, and the taste profile you tune in conversation is read by the next scheduled run. Zero external storage, zero credentials, nothing deployed on your side.
+
+---
+
+## 🚀 Features
+
+*   **Scheduled with Triggers**: One `triggers.py create` call binds the agent, environment, prompt, and cron schedule into a resource that fires on its own — pause, resume, run-now, and execution history included.
+*   **Learns Your Taste Across Runs**: Tell it "less funding news" or "add quantum computing" in chat — it updates `interests.json` in the persistent environment, and the next scheduled briefing curates differently. Every briefing includes a taste note so the learning stays visible and correctable.
+*   **Trend Analysis from Run History**: `curation_history.csv` grows sweep over sweep, letting each briefing say "mentions of X rose from 4 to 15 across the last three sweeps" — with real numbers.
+*   **Three Zero-Credential Sources**: Google News RSS (any search topic, plus genre feeds like TECHNOLOGY or SCIENCE), Hacker News (community buzz), and Medium tag feeds (longform practitioner writing) — no account, token, or paid tier for any of them; the network allowlist is exactly three domains.
+*   **Curation, Not Firehose**: Hard cap of 10 news picks + 4 community items per briefing, each with a why-it-matters line and its source link. Selection quality is the product.
+*   **Delivers Itself (optional)**: Configure a Slack, Discord, or Google Chat incoming webhook and each scheduled run pushes a condensed briefing straight into your chat — no poller, no cron on your side. Without a webhook, briefings simply accumulate in the workspace.
+
+---
+
+## ✅ Prerequisites
+
+- **Python 3.10+** with the [google-genai SDK](https://pypi.org/project/google-genai/): `pip install -r requirements.txt`.
+- A **Gemini API key** exported as `GEMINI_API_KEY` ([get one](https://aistudio.google.com/app/api-keys)).
+- No accounts, tokens, or paid tiers for the news sources; delivery to a chat webhook is optional (see below).
+
+---
+
+## ⏰ Schedule It
+
+```bash
+export GEMINI_API_KEY="your_api_key_here"
+cd news-curator
+
+# Create the daily briefing (09:00 UTC by default). Prints the trigger id — copy it.
+python3 client/triggers.py create
+
+# Use that id in the commands below (or run `list` any time to see all triggers).
+python3 client/triggers.py run <TRIGGER_ID>          # fire now, don't wait for 09:00
+python3 client/triggers.py executions <TRIGGER_ID>   # run history
+python3 client/triggers.py digest <TRIGGER_ID>       # print the latest briefing
+python3 client/triggers.py usage <TRIGGER_ID>        # token usage per execution
+python3 client/triggers.py list                      # all triggers + their ids
+```
+
+Other schedules: `--schedule "0 7 * * *" --tz "America/New_York"` (7am Eastern daily), `--schedule "0 8 * * 1-5"` (weekday mornings). Manage with `pause`, `resume`, `list`, and `delete <TRIGGER_ID>`.
+
+Run it two days in a row and compare briefings: day two contains only articles that appeared *since day one*, and its Trends section cites the history day one wrote — that's the persistent environment doing the work.
+
+---
+
+## 💬 Tune Its Taste From Your Terminal
+
+The taste profile lives in the trigger's persistent environment, so you tune it by talking to the agent *in that environment*:
+
+```bash
+python3 client/triggers.py feedback TRIGGER_ID "less funding-round news, and add Formula 1 to my topics"
+```
+
+The agent updates `interests.json`, confirms what it recorded, and the **next scheduled run curates against the updated profile**. Every briefing's Taste Note tells you which preferences shaped that day's picks, so the learning stays visible and correctable.
+
+---
+
+## 📬 Get It Delivered (optional)
+
+Give the trigger a webhook at creation time and the briefing arrives in your chat every morning by itself. Pick whichever platform you use — each is a 30-second, one-time setup.
+
+**Step 1 — create an incoming webhook and copy its URL:**
+
+| Platform | How to get a webhook URL | Notes |
+| --- | --- | --- |
+| **Discord** | Channel → *Edit Channel* → *Integrations* → *Webhooks* → *New Webhook* → *Copy Webhook URL* | Works on free personal accounts. Easiest option. |
+| **Slack** | Create an app at [api.slack.com/apps](https://api.slack.com/apps) → *Incoming Webhooks* → *Activate* → *Add New Webhook to Workspace* → pick a channel → copy the URL | Free plan works. |
+| **Google Chat** | Space → space name → *Apps & integrations* → *Webhooks* → *Add* → copy the URL | **Requires Google Workspace** — not available on personal Gmail, and some org admins disable it. If the option is missing, use Slack or Discord. |
+
+**Step 2 — export it and create the trigger** (never hardcode the URL):
+
+```bash
+export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."   # or SLACK_WEBHOOK_URL / CHAT_WEBHOOK_URL
+python3 client/triggers.py create
+```
+
+You'll see `Delivery enabled: … will be available to the deliver skill` confirming it was picked up. The URL is baked into the trigger's environment as a credentials file (not committed anywhere); the deliver skill formats the briefing for the target platform — clickable headlines, emoji section anchors — and splits it across multiple messages if it exceeds the platform's per-message limit (Discord 2k, Slack/Chat ~4k chars), so nothing is truncated. The full briefing is always saved in the workspace too. No webhook exported? Delivery is skipped silently and everything else works.
+
+> **Webhook vs. Chat app**: incoming webhooks are the right tool for one-way notifications like this. If you want two-way interaction — replying to the briefing in Chat to tune your taste profile — that's a [Google Chat app](https://developers.google.com/workspace/chat), which needs a hosted backend. The `feedback` command above gives you the same loop from the terminal without any of that infrastructure.
+
+---
+
+## 🎯 Make It Yours
+
+The reader profile ships as **`interests.default.json`** (the tracked, pristine default). On the first `./probers.sh` or `triggers.py create`, it's copied to `workspace/interests.json` — your working copy, which the agent then owns and edits as it learns your taste. To start from your own interests, either edit `interests.default.json` before the first run, or edit `workspace/interests.json` after it's created:
+
+```json
+{
+  "topics": ["your product", "rust programming", "Formula 1"],
+  "genres": ["TECHNOLOGY", "SCIENCE"],
+  "medium_tags": ["rust", "machine-learning"],
+  "preferences": {
+    "more": ["primary sources"],
+    "less": ["rumor pieces"],
+    "notes": []
+  },
+  "max_items_per_topic": 15
+}
+```
+
+Valid genres: `WORLD`, `NATION`, `BUSINESS`, `TECHNOLOGY`, `ENTERTAINMENT`, `SCIENCE`, `SPORTS`, `HEALTH`. Or just tell the agent in chat — "add quantum computing to my topics" — and it maintains the working copy itself.
+
+> `workspace/interests.json` is git-ignored runtime state the agent mutates; `interests.default.json` is the version-controlled default. Editing the working copy never shows up as a repo change.
+
+---
+
+## 🧪 Testing the Prober
+
+To test a single sweep end-to-end without creating a trigger:
+
+```bash
+export GEMINI_API_KEY="your_api_key_here"
+./probers.sh
+```
+
+Note the prober provisions a fresh environment each time, so it always behaves like a "first run" — the never-repeat-an-article and taste-learning stories only show up under a Trigger, where executions share one environment.
+
+---
+
+## 🛟 Troubleshooting
+
+- **Google Chat: no *Webhooks* option, or delivery returns HTTP 403** — incoming webhooks require Google Workspace and may be disabled by your org admin; they don't work on personal Gmail. Use Slack or Discord instead.
+- **The briefing wrote to the workspace but wasn't delivered** — check the run output (`digest <TRIGGER_ID>`); a delivery failure is reported verbatim there and never blocks the briefing itself. Confirm the webhook URL was exported *before* `create` (look for the `Delivery enabled: …` line at creation).
+- **Nothing new in a later briefing** — that's the dedupe working: only articles unseen in previous runs are surfaced. A quiet interval still produces a briefing noting "0 new items" plus the trend read.

--- a/news-curator/agent.yaml
+++ b/news-curator/agent.yaml
@@ -1,0 +1,23 @@
+id: news-curator
+base_agent: antigravity-preview-05-2026
+description: "Personalized news curator that runs on a Trigger: sweeps Google News, Hacker News, and Medium for the reader's topics and genres, learns their taste from feedback across runs, and writes a daily curated briefing with trend analysis."
+tools:
+  - type: code_execution
+environment:
+  type: "remote"
+  sources: []
+  network:
+    allowlist:
+      - domain: "news.google.com"
+      - domain: "hn.algolia.com"
+      - domain: "medium.com"
+      - domain: "chat.googleapis.com"
+      - domain: "hooks.slack.com"
+      - domain: "discord.com"
+examples:
+  - title: "Daily Briefing"
+    prompt: "Run the daily curation sweep: fetch the latest news and community discussion for my interests, curate the briefing, and update the trend history."
+  - title: "Tune My Interests"
+    prompt: "Add 'quantum computing' to my topics, and going forward show me less funding-round news."
+  - title: "Trend Check"
+    prompt: "Which of my topics has been heating up across the briefings so far?"

--- a/news-curator/client/triggers.py
+++ b/news-curator/client/triggers.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Manage the news-curator agent's schedule with the google-genai SDK.
+
+A Trigger binds this template's agent, environment, prompt, and cron schedule
+into a persistent resource that fires without manual intervention. Every
+execution reuses the SAME environment, which is what makes this template work:
+seen_items.json, interests.json, and curation_history.csv written by one run
+are read by the next, so the agent accumulates a longitudinal view with zero
+external storage.
+
+The interaction config (agent, AGENTS.md, skills, workspace files, network
+allowlist) is assembled inline below, so scheduled runs carry exactly the
+same environment sources as the template checkout they were created from.
+
+Usage (from the news-curator/ template directory):
+    export GEMINI_API_KEY="your_api_key_here"
+
+    python3 client/triggers.py create                      # daily at 09:00 UTC
+    python3 client/triggers.py create --schedule "0 */6 * * *" --tz "America/New_York"
+    python3 client/triggers.py list
+    python3 client/triggers.py run TRIGGER_ID              # fire now (works while paused)
+    python3 client/triggers.py executions TRIGGER_ID       # history + interaction ids
+    python3 client/triggers.py digest TRIGGER_ID           # print latest run's output
+    python3 client/triggers.py usage TRIGGER_ID            # token usage per execution
+    python3 client/triggers.py pause TRIGGER_ID
+    python3 client/triggers.py resume TRIGGER_ID
+    python3 client/triggers.py delete TRIGGER_ID
+
+Requires: Python 3.10+ and the google-genai SDK (`pip install google-genai`).
+"""
+
+import argparse
+import base64
+import os
+import shutil
+import sys
+import warnings
+from pathlib import Path
+
+# Keep command output clean: the SDK warns that the Triggers API (in
+# preview) may change. Drop this filter once the API is GA.
+warnings.filterwarnings("ignore", message="Triggers usage is experimental")
+
+from google import genai
+
+AGENT_ID = "antigravity-preview-05-2026"
+
+# The agent only ever needs the three news sources and the chat platforms it
+# may deliver to — everything else stays unreachable from the sandbox.
+NETWORK_ALLOWLIST = [
+    {"domain": "news.google.com"},
+    {"domain": "hn.algolia.com"},
+    {"domain": "medium.com"},
+    {"domain": "chat.googleapis.com"},
+    {"domain": "hooks.slack.com"},
+    {"domain": "discord.com"},
+]
+
+TEXT_EXTENSIONS = (".py", ".md", ".txt", ".sh", ".csv", ".env", ".json", ".yaml")
+
+DEFAULT_SCHEDULE = "0 9 * * *"  # daily at 09:00
+DEFAULT_TZ = "UTC"
+DEFAULT_PROMPT = (
+    "Run the daily curation sweep: fetch the latest news and community "
+    "discussion for my interests, curate the briefing, and update the "
+    "trend history."
+)
+
+
+def make_client():
+    if not os.environ.get("GEMINI_API_KEY"):
+        sys.exit("Error: GEMINI_API_KEY is not set.")
+    return genai.Client()
+
+
+def field(obj, name, default=None):
+    """Read a field from an SDK model or a plain dict interchangeably."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def environment_sources():
+    """Collect AGENTS.md, skills/, and workspace/ into environment sources —
+    the same layout the sandbox expects (/.agents/...)."""
+    sources = []
+
+    api_key = os.environ["GEMINI_API_KEY"]
+    sources.append({
+        "type": "inline",
+        "target": "/credentials/.env",
+        "content": f"GEMINI_API_KEY={api_key}\n",
+    })
+
+    if os.path.exists("AGENTS.md"):
+        sources.append({
+            "type": "inline",
+            "target": "/.agents/AGENTS.md",
+            "content": Path("AGENTS.md").read_text(encoding="utf-8"),
+        })
+
+    for directory in ("skills", "workspace"):
+        for path in sorted(Path(directory).rglob("*")):
+            if not path.is_file():
+                continue
+            source = {"type": "inline", "target": f"/.agents/{path.as_posix()}"}
+            if path.suffix in TEXT_EXTENSIONS:
+                try:
+                    source["content"] = path.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    source["content"] = base64.b64encode(path.read_bytes()).decode()
+                    source["encoding"] = "base64"
+            else:
+                source["content"] = base64.b64encode(path.read_bytes()).decode()
+                source["encoding"] = "base64"
+            sources.append(source)
+
+    # Optional delivery: if a webhook URL is exported when the trigger is
+    # created, bake it into the environment as a credentials file the deliver
+    # skill reads. Never hardcode webhook URLs here or in the repo.
+    for key in ("CHAT_WEBHOOK_URL", "SLACK_WEBHOOK_URL", "DISCORD_WEBHOOK_URL"):
+        url = os.environ.get(key)
+        if url:
+            sources.append({
+                "type": "inline",
+                "target": "/credentials/webhook.env",
+                "content": f"{key}={url}\n",
+            })
+            print(f"Delivery enabled: {key} will be available to the deliver skill.")
+            break
+    else:
+        print("No CHAT_WEBHOOK_URL / SLACK_WEBHOOK_URL / DISCORD_WEBHOOK_URL "
+              "exported — briefings will be written to the workspace only.")
+    return sources
+
+
+def build_interaction(prompt):
+    if not os.path.exists("AGENTS.md"):
+        sys.exit("Error: run this from the news-curator/ template directory.")
+
+    # Seed the reader profile from the shipped default if absent, so a fresh
+    # clone gets a working profile the first time a trigger is created.
+    # workspace/interests.json is git-ignored runtime state the agent edits;
+    # interests.default.json is the tracked, pristine starting point.
+    os.makedirs("workspace", exist_ok=True)
+    if not os.path.exists("workspace/interests.json") and os.path.exists("interests.default.json"):
+        shutil.copy("interests.default.json", "workspace/interests.json")
+
+    return {
+        "agent": AGENT_ID,
+        "input": prompt,
+        "tools": [{"type": "code_execution"}],
+        "environment": {
+            "type": "remote",
+            "sources": environment_sources(),
+            "network": {"allowlist": NETWORK_ALLOWLIST},
+        },
+    }
+
+
+def interaction_text(interaction):
+    parts = []
+    for step in field(interaction, "steps") or []:
+        if field(step, "type") == "model_output":
+            for item in field(step, "content") or []:
+                if field(item, "type") == "text" and field(item, "text"):
+                    parts.append(field(item, "text"))
+    return "\n".join(parts)
+
+
+def cmd_create(args):
+    client = make_client()
+    trigger = client.triggers.create(
+        schedule=args.schedule,
+        time_zone=args.tz,
+        display_name=args.name,
+        execution_timeout_seconds=600,
+        interaction=build_interaction(args.prompt),
+    )
+    print(f"Trigger created: {field(trigger, 'id')}")
+    print(f"  Status:   {field(trigger, 'status')}")
+    print(f"  Schedule: {args.schedule} ({args.tz})")
+    print(f"  Next run: {field(trigger, 'next_run_time')}")
+
+
+def cmd_list(_args):
+    client = make_client()  # hold the client: a temporary gets GC'd mid-call
+    triggers = field(client.triggers.list(), "triggers") or []
+    if not triggers:
+        print("No triggers.")
+    for t in triggers:
+        print(f"{field(t, 'id')}  {field(t, 'display_name')}  [{field(t, 'status')}]  "
+              f"next: {field(t, 'next_run_time')}")
+
+
+def cmd_run(args):
+    # The run-now call may hold the connection while the execution runs; the
+    # execution starts regardless, so a timeout here is not a failure.
+    client = make_client()
+    try:
+        client.triggers.run(args.trigger_id, timeout=15)
+    except Exception as error:  # noqa: BLE001 — only swallow timeouts
+        if "timed out" not in str(error).lower() and "timeout" not in str(error).lower():
+            raise
+    print(f"Execution requested for {args.trigger_id}. "
+          f"Watch it with: python3 client/triggers.py executions {args.trigger_id}")
+
+
+def cmd_status(args, status):
+    client = make_client()
+    client.triggers.update(args.trigger_id, status=status)
+    print(f"Trigger {args.trigger_id} -> {status}")
+
+
+def list_executions(client, trigger_id):
+    result = client.triggers.list_executions(trigger_id)
+    return field(result, "trigger_executions") or []
+
+
+def cmd_executions(args):
+    client = make_client()
+    executions = list_executions(client, args.trigger_id)
+    if not executions:
+        print("No executions yet.")
+    for ex in executions:
+        print(f"{field(ex, 'id')}  [{field(ex, 'status')}]  {field(ex, 'start_time')} -> "
+              f"{field(ex, 'end_time')}  interaction: {field(ex, 'interaction_id')}")
+
+
+def latest_interaction(client, trigger_id):
+    done = [ex for ex in list_executions(client, trigger_id) if field(ex, "interaction_id")]
+    if not done:
+        sys.exit("No executions with an interaction yet — run the trigger once first "
+                 f"(python3 client/triggers.py run {trigger_id}).")
+    latest = max(done, key=lambda ex: str(field(ex, "start_time") or ""))
+    return client.interactions.get(field(latest, "interaction_id"))
+
+
+def cmd_digest(args):
+    """Fetch the most recent execution's interaction and print its output —
+    the quickest way to read the latest briefing without opening the sandbox."""
+    client = make_client()
+    interaction = latest_interaction(client, args.trigger_id)
+    print(interaction_text(interaction) or "(no text output on the latest execution)")
+
+
+def cmd_usage(args):
+    """Print token usage per execution."""
+    client = make_client()
+    executions = [ex for ex in list_executions(client, args.trigger_id)
+                  if field(ex, "interaction_id")]
+    if not executions:
+        print("No executions with an interaction yet.")
+        return
+    executions.sort(key=lambda ex: str(field(ex, "start_time") or ""), reverse=True)
+    print(f"{'started (UTC)':<17} {'input':>9} {'cached':>9} {'output':>8} "
+          f"{'thought':>8} {'total':>9}")
+    for ex in executions:
+        usage = field(client.interactions.get(field(ex, "interaction_id")), "usage")
+        if usage is None:
+            continue
+        print(f"{str(field(ex, 'start_time'))[:16]:<17} "
+              f"{field(usage, 'total_input_tokens') or 0:>9,} "
+              f"{field(usage, 'total_cached_tokens') or 0:>9,} "
+              f"{field(usage, 'total_output_tokens') or 0:>8,} "
+              f"{field(usage, 'total_thought_tokens') or 0:>8,} "
+              f"{field(usage, 'total_tokens') or 0:>9,}")
+
+
+def cmd_delete(args):
+    client = make_client()
+    client.triggers.delete(args.trigger_id)
+    print(f"Trigger {args.trigger_id} deleted (execution history is retained).")
+
+
+def cmd_feedback(args):
+    """Send taste feedback into the trigger's PERSISTENT environment.
+
+    The agent applies its taste-learning protocol (updates interests.json)
+    and the next scheduled run curates against the updated profile — this is
+    the same environment every execution reuses."""
+    client = make_client()
+    env_id = field(latest_interaction(client, args.trigger_id), "environment_id")
+    if not env_id:
+        sys.exit("Could not resolve the trigger's environment id.")
+    print(f"Sending feedback into environment {env_id} (may take a minute)...")
+    # Interactions that reuse an environment by id do NOT auto-load the
+    # environment's AGENTS.md into context (verified empirically — trigger
+    # executions get it, bare reuse does not). So point the agent at the
+    # environment's own copy rather than duplicating the protocol here:
+    # AGENTS.md stays the single source of truth.
+    interaction = client.interactions.create(
+        agent=AGENT_ID,
+        environment=env_id,
+        input=(
+            "First read /.agents/AGENTS.md and adopt its persona and rules "
+            "for this conversation. Then handle this reader taste feedback "
+            f"per its protocol: {args.message}"
+        ),
+        timeout=620,
+    )
+    print(interaction_text(interaction) or "(no text reply)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create", help="create the scheduled sweep")
+    create.add_argument("--schedule", default=DEFAULT_SCHEDULE, help="cron expression")
+    create.add_argument("--tz", default=DEFAULT_TZ, help="IANA time zone")
+    create.add_argument("--name", default="news-curator-sweep", help="display name")
+    create.add_argument("--prompt", default=DEFAULT_PROMPT, help="sweep prompt")
+    create.set_defaults(func=cmd_create)
+
+    sub.add_parser("list", help="list triggers").set_defaults(func=cmd_list)
+
+    feedback = sub.add_parser(
+        "feedback",
+        help="send taste feedback into the trigger's environment "
+             '(e.g. feedback TRIGGER_ID "less funding news")',
+    )
+    feedback.add_argument("trigger_id")
+    feedback.add_argument("message")
+    feedback.set_defaults(func=cmd_feedback)
+
+    for name, help_text in [("run", "fire immediately"), ("executions", "show run history"),
+                            ("digest", "print the latest run's briefing output"),
+                            ("usage", "show token usage per execution"),
+                            ("pause", "pause the schedule"), ("resume", "resume the schedule"),
+                            ("delete", "delete the trigger")]:
+        p = sub.add_parser(name, help=help_text)
+        p.add_argument("trigger_id")
+        if name == "pause":
+            p.set_defaults(func=lambda a: cmd_status(a, "paused"))
+        elif name == "resume":
+            p.set_defaults(func=lambda a: cmd_status(a, "active"))
+        elif name == "run":
+            p.set_defaults(func=cmd_run)
+        elif name == "executions":
+            p.set_defaults(func=cmd_executions)
+        elif name == "digest":
+            p.set_defaults(func=cmd_digest)
+        elif name == "usage":
+            p.set_defaults(func=cmd_usage)
+        else:
+            p.set_defaults(func=cmd_delete)
+
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except Exception as error:
+        # Surface SDK/API failures as a one-line message, not a traceback.
+        if type(error).__module__.startswith("google.genai"):
+            sys.exit(f"API error: {error}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/news-curator/interests.default.json
+++ b/news-curator/interests.default.json
@@ -1,0 +1,11 @@
+{
+  "topics": ["Gemini API", "artificial intelligence"],
+  "genres": ["TECHNOLOGY"],
+  "medium_tags": ["gemini", "artificial-intelligence"],
+  "preferences": {
+    "more": ["hands-on engineering detail", "primary sources and official announcements"],
+    "less": ["rumor and speculation pieces", "listicles"],
+    "notes": []
+  },
+  "max_items_per_topic": 15
+}

--- a/news-curator/probers.sh
+++ b/news-curator/probers.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+if [ -z "$GEMINI_API_KEY" ]; then
+  echo "Error: GEMINI_API_KEY is not set."
+  exit 1
+fi
+
+# Seed the reader profile from the shipped default on first run.
+mkdir -p workspace
+[ -f workspace/interests.json ] || cp interests.default.json workspace/interests.json
+
+# Read prompt from first example in agent.yaml
+PROMPT=$(python3 -c "import yaml; print(yaml.safe_load(open('agent.yaml'))['examples'][0]['prompt'])")
+
+# Generate payload
+python3 ../generate_payload.py "$PROMPT" > probers.json
+
+# Send request (saving output to prober_output.log)
+curl -X POST "https://generativelanguage.googleapis.com/v1beta/interactions" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "x-goog-api-key: $GEMINI_API_KEY" \
+  -H "Api-Revision: 2026-05-20" \
+  -H "x-server-timeout: 600" \
+  -d @probers.json > prober_output.log
+
+# Clean up
+rm probers.json

--- a/news-curator/requirements.txt
+++ b/news-curator/requirements.txt
@@ -1,0 +1,1 @@
+google-genai>=2.12.0

--- a/news-curator/skills/briefing/SKILL.md
+++ b/news-curator/skills/briefing/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: briefing
+description: Formats the standalone daily briefing — curated picks with why-it-matters lines, community buzz, the trend read across runs, and the taste note that keeps the learning visible.
+---
+
+# Briefing Skill
+
+Use this skill to end every sweep. The briefing is the run's product: it must
+be fully understandable by someone who reads nothing else — no "as I
+mentioned", no open questions, no references to the conversation.
+
+## Instructions for the Agent
+
+Write `.agents/workspace/briefings/<YYYY-MM-DD-HHMM>.md` (UTC, from `date -u`).
+Create the `briefings/` directory if needed.
+
+> [!IMPORTANT]
+> **Exact structure required.** The delivery step parses this file to build
+> the chat message, so follow the heading structure precisely:
+> - the title is a single `#` line,
+> - each section is a `##` line,
+> - **every item** — in every section — is a `### [headline] — [source]`
+>   line, followed by its why-it-matters sentence, followed by a link line
+>   `[Source Link](url)`.
+>
+> Do NOT use tables, bullet lists for items, or any other layout for the
+> curated items. The `###`-heading-plus-link shape is what makes each
+> headline render as a clean clickable link. (Trends, Taste Note, and Data
+> Health are prose/bullets, not items — they have no `###` entries.)
+
+Use this exact layout:
+
+```markdown
+# Daily Briefing — [date] — [reader's topics, comma-separated]
+
+## Top Stories
+### [headline] — [outlet]
+[1-2 sentences: why this matters to THIS reader, tied to their topics or
+stated preferences. Mention breadth if multiple outlets covered it.]
+[Source Link](url)
+
+### [headline] — [outlet]
+[why-it-matters sentence]
+[Source Link](url)
+
+## Discoveries
+### [headline] — [outlet]
+[one line on why this genre-feed item outside the explicit topics earned a slot]
+[Source Link](url)
+
+## Community Buzz
+### [paraphrased comment/story hook] — Hacker News, [n] points
+[One line on what the discussion adds beyond the news coverage.]
+[Source Link](url)
+
+## Worth a Longer Read
+### [title] — Medium (by [author])
+[one line on the depth it offers; member-only stories may be paywalled at the link]
+[Source Link](url)
+
+## Trends
+[2-4 sentences computed from curation_history.csv: which topics are heating
+up or cooling across sweeps, with the numbers cited
+("Gemini API: 4 → 9 → 15 items over the last three sweeps").
+First run: "First sweep — trend data starts today."]
+
+## Taste Note
+[1-3 sentences: which stored preferences shaped today's selection, any
+profile change made since the last run, and — at most once per week — one
+question-free observation the reader could correct
+(e.g. "I've been down-ranking funding news per your 2026-07-15 note.").]
+
+## Data Health
+- Fetched: [new_count] new items ([x] news, [y] community, [z] longform) · History rows: [line count of curation_history.csv]
+- [Source errors from new_items.json verbatim, or "All sources healthy."]
+```
+
+Rules:
+1. Omit an entire section (its `##` header included) when nothing qualified —
+   never emit an empty section or a placeholder item.
+2. Every item links to its source. Headlines may be lightly trimmed but never
+   rewritten into something the outlet did not say.
+3. Community items are paraphrased (≤ 25 words) — never reproduce full comment
+   text.
+4. Every number is derived, never guessed: `Fetched` counts come from
+   `new_items.json` (`new_count` and the per-item `source` field), and
+   `History rows` from the line count of `curation_history.csv`. If you cannot
+   derive a number, omit it rather than estimate.
+5. The Taste Note never asks a question — scheduled runs have no one to answer.
+   It states, in declarative form, what the reader could correct in chat later.
+6. Keep it plain and factual — no meta-commentary about cognitive load,
+   utility, or attention; just the news and why it matters.

--- a/news-curator/skills/curation/SKILL.md
+++ b/news-curator/skills/curation/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: curation
+description: Selection and ranking rules — how to turn the raw fetched pool into the handful of items the reader actually wants, guided by the taste profile in interests.json.
+---
+
+# Curation Skill
+
+Curation is editing, not summarizing. From the candidate pool in
+`new_items.json`, choose the items this specific reader should see today.
+
+## Selection Rules
+
+1. **The taste profile decides.** Re-read `interests.json` before selecting.
+   `preferences.more` entries boost an item; `preferences.less` entries drop it
+   unless it is genuinely major; `preferences.notes` carry dated, specific
+   guidance from past feedback — treat recent notes as the strongest signal.
+2. **Cap the briefing at 10 news items total** across all topics, and up to 4
+   community-buzz items. Fewer is fine; padding is not. If a topic produced
+   nothing worth including, say so in one line rather than including filler.
+3. **Prefer, in order**: primary sources and official announcements → original
+   reporting → high-engagement community discussion → aggregation/commentary.
+   Drop listicles and rumor pieces by default (they are on the default
+   `less` list).
+4. **Collapse duplicates of one story.** When several outlets carry the same
+   development, pick the strongest single link and mention coverage breadth in
+   the why-it-matters line ("also covered by Reuters and The Verge") — breadth
+   itself is a signal the story matters.
+5. **Genre feeds are the serendipity channel.** Pick at most 2-3 genre items
+   the reader did not explicitly ask about but would plausibly care about,
+   given their profile. Label them as discoveries.
+6. **Community items are for signal, not noise.** Select a Hacker News item
+   only when it adds something the news coverage lacks: practitioner
+   experience, technical pushback, or early buzz on something not yet covered.
+7. **Longform earns its slot with depth.** Select at most 2 Medium pieces per
+   briefing, and only for genuine substance — tutorials, architecture
+   write-ups, first-hand experience reports. Medium has no engagement signal
+   in the feed, so judge entirely on title substance and taste-profile fit;
+   skip anything that reads as engagement-bait or paywalled teaser fluff.
+
+## Ranking Within the Briefing
+
+Lead with the item that best combines: relevance to an explicit topic,
+recency, source quality, and taste-profile fit. Genre discoveries and
+community buzz always come after the reader's explicit topics.
+
+## What Never Gets Selected
+
+- Items you cannot link.
+- Items whose headline alone is too thin to say why it matters — do not pad
+  with invented detail.
+- Pure engagement-bait framed as news, regardless of topic match.

--- a/news-curator/skills/deliver/SKILL.md
+++ b/news-curator/skills/deliver/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: deliver
+description: Posts a condensed version of the briefing to a Google Chat or Slack incoming webhook, so the daily run delivers itself — skips silently when no webhook is configured.
+---
+
+# Deliver Skill
+
+Use this skill as the final step of a sweep, after the briefing file is
+written. It closes the last mile: instead of the briefing waiting in the
+workspace until someone polls for it, the run pushes a condensed version to
+a chat space.
+
+## Usage
+
+```bash
+python3 skills/deliver/scripts/deliver.py .agents/workspace/briefings/<file>.md
+```
+
+The script:
+1. Looks for a webhook URL in `/credentials/webhook.env` (written into the
+   environment by `client/triggers.py create` when `CHAT_WEBHOOK_URL` or
+   `SLACK_WEBHOOK_URL` is set at creation time).
+2. **If none is configured, prints a skip notice and exits 0** — delivery is
+   optional and its absence is never an error.
+3. Condenses the briefing markdown for chat (headings bolded, links kept,
+   capped below the ~4,096-character Chat message limit, with a note that the
+   full briefing lives in the workspace).
+4. POSTs `{"text": ...}` to the webhook — the same wire format works for both
+   Google Chat and Slack incoming webhooks.
+
+## Instructions for the Agent
+
+- Run this exactly once per sweep, after the briefing file exists, passing the
+  briefing's path.
+- A "skipping delivery" message is normal operation — do not mention it as a
+  problem in your output.
+- If the POST fails (non-2xx), report the status and response body verbatim in
+  your final output — the briefing itself is already safely written, so a
+  delivery failure never warrants rewriting it or retrying more than once.

--- a/news-curator/skills/deliver/scripts/deliver.py
+++ b/news-curator/skills/deliver/scripts/deliver.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Deliver a condensed briefing to a Google Chat or Slack incoming webhook.
+
+Delivery is optional: when no webhook is configured this script prints a
+skip notice and exits 0, so the same template works with or without it.
+Both Chat and Slack accept the same `{"text": ...}` payload.
+"""
+
+import json
+import re
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+MAX_CHARS = 3800  # stay under Google Chat's ~4096-char text message limit
+
+# Emoji anchors give the eye a scanning target at each section boundary.
+SECTION_EMOJI = {
+    "daily briefing": "🗞️", "top stories": "📰", "discoveries": "🔭",
+    "community buzz": "💬", "worth a longer read": "📖", "trends": "📈",
+    "taste note": "🎛️", "data health": "✅",
+}
+# Matches [text](url) and tolerates [text](<url>) — the agent may or may not
+# wrap the URL in angle brackets.
+LINK_RE = re.compile(r"\[([^\]]+)\]\(<?(https?://[^)\s>]+)>?\)")
+
+CREDENTIAL_CANDIDATES = [
+    Path("/credentials/webhook.env"),
+    Path("credentials/webhook.env"),
+]
+WEBHOOK_KEYS = ("CHAT_WEBHOOK_URL", "SLACK_WEBHOOK_URL", "DISCORD_WEBHOOK_URL")
+
+
+def load_webhook_url():
+    for path in CREDENTIAL_CANDIDATES:
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            key, _, value = line.partition("=")
+            if key.strip() in WEBHOOK_KEYS and value.strip():
+                return value.strip()
+    return None
+
+
+def condense(markdown, platform):
+    """Flatten briefing markdown into chat-friendly text under the size cap.
+
+    Markup dialects differ: Chat/Slack bold is *text*, Discord bold is
+    **text** (single asterisks are italic there). On Discord, bare URLs also
+    auto-expand into preview embeds — wrapping them in <...> suppresses that
+    and keeps the message compact."""
+    discord = platform == "discord"
+    bold = (lambda s: f"**{s}**") if discord else (lambda s: f"*{s}*")
+    # Slack/Google Chat share <url|text>; Discord uses [text](<url>) (the
+    # <...> suppresses its link-preview embed). Both hide giant redirect URLs.
+    masked = (lambda text, url: f"[{text}](<{url}>)") if discord \
+        else (lambda text, url: f"<{url}|{text}>")
+
+    # Parse into blocks of [heading level, heading text, body lines]. A block
+    # (a heading plus everything under it) is never split across messages, so
+    # a story is never shown without its link.
+    parsed, cur = [], None
+    for raw in markdown.splitlines():
+        line = raw.rstrip()
+        heading = re.match(r"^(#{1,6})\s+(.*)", line)
+        if heading:
+            if cur is not None:
+                parsed.append(cur)
+            cur = [len(heading.group(1)), heading.group(2).strip(), []]
+        elif cur is not None:
+            cur[2].append(line)
+        elif line.strip():
+            cur = [0, None, [line]]
+    if cur is not None:
+        parsed.append(cur)
+
+    blocks = []
+    for level, title, body in parsed:
+        # Pull the story's source URL out of the body and drop the standalone
+        # "Source Link" line — the headline itself becomes the clickable link.
+        url, kept = None, []
+        for bl in body:
+            stripped = bl.strip().lstrip(">").strip()
+            match = LINK_RE.search(stripped)
+            if match and url is None:
+                url = match.group(2)
+            if match and LINK_RE.sub("", stripped).strip(" —-·|") == "":
+                continue  # line was only a source-link label
+            converted = LINK_RE.sub(
+                lambda m: masked(m.group(1), m.group(2)), bl.lstrip("> "))
+            if not discord:
+                converted = converted.replace("**", "*")
+            kept.append(converted)
+
+        rendered = []
+        if title and level >= 3:            # story headline → clickable + bold
+            rendered.append(bold(masked(title, url) if url else title))
+        elif title:                         # section header / title → emoji anchor
+            emoji = SECTION_EMOJI.get(title.lower().split(" — ")[0].strip())
+            rendered.append(bold(f"{emoji} {title}" if emoji else title))
+        rendered.extend(kept)
+        block = re.sub(r"\n{3,}", "\n\n", "\n".join(rendered).strip())
+        if block:
+            blocks.append(block)
+
+    # Pack whole blocks into messages. Discord caps content at 2000 chars,
+    # so overflow continues into follow-up messages (at most MAX_MESSAGES);
+    # Chat/Slack get one larger message. Anything that still does not fit is
+    # dropped at a block boundary with a truncation notice.
+    max_chars = 1900 if discord else MAX_CHARS
+    max_messages = 3  # both platforms split long briefings rather than truncate
+    messages, buffer = [], ""
+    truncated = False
+    for block in blocks:
+        candidate = f"{buffer}\n\n{block}".strip() if buffer else block
+        if len(candidate) <= max_chars:
+            buffer = candidate
+        elif len(messages) + 1 < max_messages:
+            messages.append(buffer)
+            buffer = block[:max_chars]
+        else:
+            truncated = True
+            break
+    if truncated:
+        notice = "\n\n_(continued in the full briefing in the workspace)_"
+        buffer = buffer[: max_chars - len(notice)] + notice
+    if buffer:
+        messages.append(buffer)
+    return messages
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("Usage: deliver.py <path-to-briefing.md>")
+    briefing_path = Path(sys.argv[1])
+    if not briefing_path.exists():
+        sys.exit(f"Error: briefing not found: {briefing_path}")
+
+    url = load_webhook_url()
+    if not url:
+        print("No webhook configured — skipping delivery (this is normal).")
+        return
+
+    # Google Chat and Slack take {"text": ...}; Discord takes {"content": ...}
+    # with a 2000-char cap, so long briefings go out as consecutive messages.
+    platform = "discord" if ("discord.com" in url or "discordapp.com" in url) else "chat"
+    messages = condense(briefing_path.read_text(encoding="utf-8"), platform)
+    payload_key = "content" if platform == "discord" else "text"
+
+    for index, message in enumerate(messages, start=1):
+        request = urllib.request.Request(
+            url,
+            data=json.dumps({payload_key: message}).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                # Identify ourselves properly: Discord/Cloudflare reject the
+                # default Python-urllib user agent (HTTP 403, error code 1010).
+                "User-Agent": "news-curator-deliver/1.0 (Gemini Managed Agents template)",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                print(f"Delivered part {index}/{len(messages)} (HTTP {response.status}).")
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            sys.exit(f"Delivery failed on part {index}/{len(messages)}: "
+                     f"HTTP {error.code}: {body[:500]}")
+        if index < len(messages):
+            time.sleep(1)  # keep ordering and stay far from rate limits
+
+
+if __name__ == "__main__":
+    main()

--- a/news-curator/skills/fetch-news/SKILL.md
+++ b/news-curator/skills/fetch-news/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: fetch-news
+description: Pulls the latest Google News and Hacker News items for every topic and genre in the reader's interests, deduped against every item shown in previous runs.
+---
+
+# Fetch News Skill
+
+Use this skill at the start of every sweep. It queries two public sources —
+no account, credentials, or API key required for either — and owns the
+cross-run dedupe state:
+
+- **Google News RSS** (`news.google.com`) — a search feed per topic plus a
+  headline feed per genre (`WORLD`, `NATION`, `BUSINESS`, `TECHNOLOGY`,
+  `ENTERTAINMENT`, `SCIENCE`, `SPORTS`, `HEALTH`)
+- **Hacker News** via the Algolia search API (`hn.algolia.com`) — stories and
+  comments per topic, for the community-buzz angle
+- **Medium RSS** (`medium.com`) — long-form posts per tag from
+  `interests.json`'s `medium_tags`, for the practitioner-writing angle
+
+## Usage
+
+```bash
+python3 skills/fetch-news/scripts/fetch_news.py
+```
+
+Topics, genres, and the per-topic cap all come from
+`.agents/workspace/interests.json` — change that file, not the script.
+
+The script:
+1. Reads the interests profile.
+2. Fetches every topic (both sources) and every genre (Google News). If a
+   source fails for one topic, the sweep continues and records the error in
+   `source_errors`.
+3. Drops every item whose id is already in `.agents/workspace/seen_items.json`,
+   then adds the new ids to that file (bootstrapping it on the first run).
+4. Writes the fresh items to `.agents/workspace/new_items.json` and prints them
+   to stdout, with a one-line summary on stderr.
+
+## Output format (`new_items.json`)
+
+```json
+{
+  "topics": ["Gemini API"],
+  "genres": ["TECHNOLOGY"],
+  "fetched_at": "2026-07-15T09:00:03Z",
+  "source_errors": [],
+  "new_count": 42,
+  "items": [
+    {
+      "id": "gn:CBMiXyz…",
+      "source": "news",
+      "outlet": "The Verge",
+      "title": "…headline…",
+      "context": null,
+      "url": "https://news.google.com/rss/articles/…",
+      "published": "2026-07-15T08:12:44Z",
+      "engagement": null,
+      "topic": "Gemini API"
+    },
+    {
+      "id": "hn:44581234",
+      "source": "community",
+      "outlet": "Hacker News (comment by example_dev)",
+      "title": "…comment text…",
+      "context": "Title of the story the comment is on",
+      "url": "https://news.ycombinator.com/item?id=44581234",
+      "published": "2026-07-15T07:03:10Z",
+      "engagement": 12,
+      "topic": "Gemini API"
+    }
+  ]
+}
+```
+
+`source` is `news` (Google News), `community` (Hacker News), or `longform`
+(Medium, with ids prefixed `md:` and `topic: "medium:<tag>"`). `engagement`
+is only present for community items (points or comment count). Genre items
+carry `topic: "genre:<name>"`.
+
+## Instructions for the Agent
+
+- Run this exactly once per sweep. Running it twice in one sweep marks items
+  as seen without you having curated them.
+- Treat `items` as the complete candidate pool for the sweep. `new_count: 0`
+  means a quiet interval — still write the briefing.
+- If `source_errors` is non-empty, name the degraded source in the briefing —
+  the counts only cover the sources that responded.

--- a/news-curator/skills/fetch-news/scripts/fetch_news.py
+++ b/news-curator/skills/fetch-news/scripts/fetch_news.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fetch fresh news and community discussion for the reader's interests,
+deduped across runs.
+
+Sources (all public, no account or API key required):
+  - Google News RSS: search feed per topic + headline feed per genre
+  - Hacker News via the Algolia search API: stories + comments per topic
+  - Medium RSS: long-form posts per tag (e.g. medium.com/feed/tag/gemini)
+
+The cross-run seen-set lives in the workspace so a scheduled Trigger only
+ever surfaces items it has not shown before. If a source fails, the sweep
+continues with the others and records the failure in the output.
+"""
+
+import html
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+GOOGLE_NEWS_BASE = "https://news.google.com/rss"
+HN_SEARCH_URL = "https://hn.algolia.com/api/v1/search_by_date"
+MEDIUM_FEED_BASE = "https://medium.com/feed/tag"
+DC_CREATOR = "{http://purl.org/dc/elements/1.1/}creator"
+FEED_LOCALE = "hl=en-US&gl=US&ceid=US:en"
+VALID_GENRES = {"WORLD", "NATION", "BUSINESS", "TECHNOLOGY", "ENTERTAINMENT",
+                "SCIENCE", "SPORTS", "HEALTH"}
+SEEN_CAP = 8000  # keep the dedupe file bounded across long-lived schedules
+
+WORKSPACE_CANDIDATES = [
+    Path(".agents/workspace"),
+    Path("/.agents/workspace"),
+    Path("workspace"),
+]
+
+
+def find_workspace():
+    for candidate in WORKSPACE_CANDIDATES:
+        if (candidate / "interests.json").exists():
+            return candidate
+    sys.exit("Error: could not locate workspace containing interests.json")
+
+
+def http_get(url):
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "gemini-managed-agent-news-curator/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def clean_text(text):
+    return html.unescape(re.sub(r"<[^>]+>", " ", text or "")).strip()
+
+
+def iso_date(rfc822):
+    try:
+        return parsedate_to_datetime(rfc822).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception:
+        return rfc822 or ""
+
+
+def parse_google_rss(xml_text, topic, limit):
+    items = []
+    for item in ET.fromstring(xml_text).iter("item"):
+        title = clean_text(item.findtext("title"))
+        link = (item.findtext("link") or "").strip()
+        guid = (item.findtext("guid") or link).strip()
+        if not title or not guid:
+            continue
+        outlet = clean_text(item.findtext("source")) or "unknown"
+        # Google News titles end with " - Outlet"; drop the duplication.
+        if outlet != "unknown" and title.endswith(f"- {outlet}"):
+            title = title[: -len(outlet) - 2].strip()
+        items.append({
+            "id": "gn:" + guid[-64:],
+            "source": "news",
+            "outlet": outlet,
+            "title": title[:300],
+            "context": None,
+            "url": link,
+            "published": iso_date(item.findtext("pubDate")),
+            "engagement": None,
+            "topic": topic,
+        })
+        if len(items) >= limit:
+            break
+    return items
+
+
+def fetch_topic_news(topic, limit):
+    query = urllib.parse.quote(topic)
+    url = f"{GOOGLE_NEWS_BASE}/search?q={query}&{FEED_LOCALE}"
+    return parse_google_rss(http_get(url), topic, limit)
+
+
+def fetch_genre_news(genre, limit):
+    genre = genre.upper()
+    if genre not in VALID_GENRES:
+        raise ValueError(f"unknown genre {genre!r}; valid: {', '.join(sorted(VALID_GENRES))}")
+    url = f"{GOOGLE_NEWS_BASE}/headlines/section/topic/{genre}?{FEED_LOCALE}"
+    return parse_google_rss(http_get(url), f"genre:{genre.lower()}", limit)
+
+
+def fetch_hackernews(topic, limit):
+    params = urllib.parse.urlencode({
+        "query": topic, "tags": "(story,comment)", "hitsPerPage": limit,
+    })
+    hits = json.loads(http_get(f"{HN_SEARCH_URL}?{params}")).get("hits", [])
+    items = []
+    for hit in hits:
+        object_id = hit.get("objectID")
+        if not object_id:
+            continue
+        is_story = hit.get("title") is not None
+        text = hit.get("title") if is_story else clean_text(hit.get("comment_text"))
+        if not text:
+            continue
+        items.append({
+            "id": f"hn:{object_id}",
+            "source": "community",
+            "outlet": f"Hacker News ({'story' if is_story else 'comment'} by {hit.get('author', 'unknown')})",
+            "title": text[:300] if is_story else text[:500],
+            "context": None if is_story else hit.get("story_title"),
+            "url": f"https://news.ycombinator.com/item?id={object_id}",
+            "published": (hit.get("created_at") or "").replace(".000Z", "Z"),
+            "engagement": hit.get("points") or hit.get("num_comments") or 0,
+            "topic": topic,
+        })
+    return items
+
+
+def fetch_medium(tag, limit):
+    tag = tag.strip().lstrip("#").lower().replace(" ", "-")
+    xml_text = http_get(f"{MEDIUM_FEED_BASE}/{urllib.parse.quote(tag)}")
+    items = []
+    for item in ET.fromstring(xml_text).iter("item"):
+        title = clean_text(item.findtext("title"))
+        link = (item.findtext("link") or "").split("?")[0].strip()
+        guid = (item.findtext("guid") or link).strip()
+        if not title or not guid:
+            continue
+        author = clean_text(item.findtext(DC_CREATOR)) or "unknown"
+        items.append({
+            "id": "md:" + guid.rsplit("/", 1)[-1][-64:],
+            "source": "longform",
+            "outlet": f"Medium (by {author})",
+            "title": title[:300],
+            "context": None,
+            "url": link,
+            "published": iso_date(item.findtext("pubDate")),
+            "engagement": None,
+            "topic": f"medium:{tag}",
+        })
+        if len(items) >= limit:
+            break
+    return items
+
+
+def main():
+    workspace = find_workspace()
+    interests = json.loads((workspace / "interests.json").read_text(encoding="utf-8"))
+    topics = interests.get("topics", [])
+    genres = interests.get("genres", [])
+    medium_tags = interests.get("medium_tags", [])
+    per_topic = int(interests.get("max_items_per_topic", 15))
+    if not topics and not genres and not medium_tags:
+        sys.exit("Error: interests.json has no topics, genres, or medium_tags to sweep.")
+
+    seen_path = workspace / "seen_items.json"
+    seen = []
+    if seen_path.exists():
+        seen = json.loads(seen_path.read_text(encoding="utf-8")).get("seen", [])
+    seen_set = set(seen)
+
+    fetched, errors = [], []
+    for topic in topics:
+        try:
+            fetched += fetch_topic_news(topic, per_topic)
+        except Exception as error:
+            errors.append(f"google-news[{topic}]: {error}")
+        try:
+            fetched += fetch_hackernews(topic, max(3, per_topic // 3))
+        except Exception as error:
+            errors.append(f"hackernews[{topic}]: {error}")
+    for genre in genres:
+        try:
+            fetched += fetch_genre_news(genre, per_topic)
+        except Exception as error:
+            errors.append(f"google-news[genre:{genre}]: {error}")
+    for tag in medium_tags:
+        try:
+            fetched += fetch_medium(tag, max(3, per_topic // 3))
+        except Exception as error:
+            errors.append(f"medium[{tag}]: {error}")
+
+    if errors and not fetched:
+        sys.exit("Error: every source failed: " + "; ".join(errors))
+
+    unique = {}
+    for item in fetched:  # an item can match several topics; keep the first
+        unique.setdefault(item["id"], item)
+    new_items = [item for iid, item in unique.items() if iid not in seen_set]
+    new_items.sort(key=lambda item: item["published"], reverse=True)
+
+    seen.extend(item["id"] for item in new_items)
+    seen = seen[-SEEN_CAP:]
+    seen_path.write_text(json.dumps({"seen": seen}, indent=2), encoding="utf-8")
+
+    result = {
+        "topics": topics,
+        "genres": genres,
+        "fetched_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_errors": errors,
+        "new_count": len(new_items),
+        "items": new_items,
+    }
+    (workspace / "new_items.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    print(json.dumps(result, indent=2))
+    print(
+        f"Sweep complete: {len(unique)} unique items fetched across "
+        f"{len(topics)} topics + {len(genres)} genres + {len(medium_tags)} medium tags "
+        f"({len(new_items)} new after dedupe, {len(seen)} ids tracked)"
+        + (f" — source errors: {'; '.join(errors)}" if errors else ""),
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sweeps Google News, Hacker News, and Medium for the reader's topics on a Trigger, curates a daily briefing with trend analysis, and learns the reader's taste from feedback across runs via the persistent environment. 

Optional delivery to Discord, Slack, or Google Chat incoming webhooks. 

Trigger lifecycle is managed with the google-genai SDK (client.triggers / client.interactions).